### PR TITLE
chore: Run `make upgrade`

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -29,11 +29,11 @@ bleach==6.0.0
     # via
     #   -r requirements/test.txt
     #   readme-renderer
-boto3==1.26.156
+boto3==1.26.160
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.29.156
+botocore==1.29.160
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -174,7 +174,7 @@ jmespath==1.0.1
     #   -r requirements/test.txt
     #   boto3
     #   botocore
-keyring==24.0.0
+keyring==24.2.0
     # via
     #   -r requirements/test.txt
     #   twine
@@ -237,13 +237,13 @@ pkginfo==1.9.6
     # via
     #   -r requirements/test.txt
     #   twine
-platformdirs==3.6.0
+platformdirs==3.8.0
     # via
     #   -r requirements/test.txt
     #   -r requirements/tox.txt
     #   pylint
     #   virtualenv
-pluggy==1.0.0
+pluggy==1.2.0
     # via
     #   -r requirements/test.txt
     #   -r requirements/tox.txt
@@ -288,7 +288,7 @@ pypng==0.20220715.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-pytest==7.3.2
+pytest==7.4.0
     # via
     #   -r requirements/test.txt
     #   pytest-django

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -20,9 +20,9 @@ binaryornot==0.4.4
     # via cookiecutter
 bleach==6.0.0
     # via readme-renderer
-boto3==1.26.156
+boto3==1.26.160
     # via fs-s3fs
-botocore==1.29.156
+botocore==1.29.160
     # via
     #   boto3
     #   s3transfer
@@ -98,7 +98,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-keyring==24.0.0
+keyring==24.2.0
     # via twine
 lazy==1.5
     # via xblock
@@ -133,7 +133,7 @@ pbr==5.11.1
     # via stevedore
 pkginfo==1.9.6
     # via twine
-platformdirs==3.6.0
+platformdirs==3.8.0
     # via pylint
 pycodestyle==2.10.0
     # via -r requirements/quality.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -20,9 +20,9 @@ binaryornot==0.4.4
     # via cookiecutter
 bleach==6.0.0
     # via readme-renderer
-boto3==1.26.156
+boto3==1.26.160
     # via fs-s3fs
-botocore==1.29.156
+botocore==1.29.160
     # via
     #   boto3
     #   s3transfer
@@ -108,7 +108,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-keyring==24.0.0
+keyring==24.2.0
     # via twine
 lazy==1.5
     # via xblock
@@ -147,9 +147,9 @@ pbr==5.11.1
     # via stevedore
 pkginfo==1.9.6
     # via twine
-platformdirs==3.6.0
+platformdirs==3.8.0
     # via pylint
-pluggy==1.0.0
+pluggy==1.2.0
     # via pytest
 pycodestyle==2.10.0
     # via -r requirements/test.in
@@ -175,7 +175,7 @@ pylint-plugin-utils==0.8.2
     #   pylint-django
 pypng==0.20220715.0
     # via xblock-sdk
-pytest==7.3.2
+pytest==7.4.0
     # via
     #   -r requirements/test.in
     #   pytest-django

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -12,9 +12,9 @@ filelock==3.12.2
     #   virtualenv
 packaging==23.1
     # via tox
-platformdirs==3.6.0
+platformdirs==3.8.0
     # via virtualenv
-pluggy==1.0.0
+pluggy==1.2.0
     # via tox
 py==1.11.0
     # via tox


### PR DESCRIPTION
Manually run `make upgrade` because the automation seems to be failing
with some network calls to automaticall create PRs.
