### PR TITLE
feat: improve studio settings menu

### DIFF
--- a/feedback/feedback.py
+++ b/feedback/feedback.py
@@ -12,7 +12,7 @@ import pkg_resources
 import six
 
 from xblock.core import XBlock
-from xblock.fields import Scope, Integer, String, List, Float
+from xblock.fields import Scope, Integer, String, List, Float, Boolean
 from web_fragments.fragment import Fragment
 try:
     from xblock.utils.resources import ResourceLoader
@@ -109,6 +109,24 @@ class FeedbackXBlock(XBlock):
         scopde=Scope.settings
     )
 
+    voting_message = String(
+        display_name=_("Voting message"),
+        default=_("Thank you for voting!"),
+        scope=Scope.settings
+    )
+
+    feedback_message = String(
+        display_name=_("Feedback message"),
+        default=_("Thank you for your feedback!"),
+        scope=Scope.settings
+    )
+
+    show_aggregate_to_students = Boolean(
+        display_name=_("Show aggregate to students"),
+        default=False,
+        scope=Scope.settings
+    )
+
     @classmethod
     def resource_string(cls, path):
         """Handy helper for getting resources from our kit."""
@@ -165,7 +183,7 @@ class FeedbackXBlock(XBlock):
         prompt = self.get_prompt()
 
         # Staff see vote totals, so we have slightly different HTML here.
-        if self.vote_aggregate and self.is_staff():
+        if self.vote_aggregate and (self.show_aggregate_to_students or self.is_staff()):
             item_templates_file = "templates/html/staff_item.html"
         else:
             item_templates_file = "templates/html/scale_item.html"
@@ -240,7 +258,7 @@ class FeedbackXBlock(XBlock):
         )
         if self.user_vote != -1:
             _ = self.runtime.service(self, 'i18n').ugettext
-            response = _("Thank you for voting!")
+            response = self.voting_message
         else:
             response = ""
 
@@ -283,6 +301,13 @@ class FeedbackXBlock(XBlock):
         for idx in range(len(prompt['scale_text'])):
             prompt['likert{i}'.format(i=idx)] = prompt['scale_text'][idx]
         frag = Fragment()
+
+        prompt.update({
+            "display_name": self.display_name,
+            "voting_message": self.voting_message,
+            "feedback_message": self.feedback_message,
+            "show_aggregate_to_students": self.show_aggregate_to_students,
+        })
         frag.add_content(resource_loader.render_django_template(
             'templates/html/studio_view.html',
             prompt,
@@ -308,6 +333,11 @@ class FeedbackXBlock(XBlock):
             likert = data.get('likert{i}'.format(i=i), None)
             if likert and len(likert) > 0:
                 self.prompts[0]['scale_text'][i] = html.escape(likert)
+
+        self.display_name = data.get('display_name')
+        self.voting_message = data.get('voting_message')
+        self.feedback_message = data.get('feedback_message')
+        self.show_aggregate_to_students = data.get("show_aggregate_to_students")
 
         return {'result': 'success'}
 
@@ -361,7 +391,7 @@ class FeedbackXBlock(XBlock):
                                  {})
         if 'vote' in data:
             response = {"success": True,
-                        "response": _("Thank you for voting!")}
+                        "response": self.voting_message}
             self.runtime.publish(self,
                                  'edx.feedbackxblock.likert_provided',
                                  {'old_vote': self.user_vote,
@@ -369,7 +399,7 @@ class FeedbackXBlock(XBlock):
             self.vote(data)
         if 'freeform' in data:
             response = {"success": True,
-                        "response": _("Thank you for your feedback!")}
+                        "response": self.feedback_message}
             self.runtime.publish(self,
                                  'edx.feedbackxblock.freeform_provided',
                                  {'old_freeform': self.user_freeform,

--- a/feedback/static/js/src/studio.js
+++ b/feedback/static/js/src/studio.js
@@ -2,6 +2,7 @@ function FeedbackBlock(runtime, element, data) {
     // When the user asks to save, read the form data and send it via AJAX
     $(element).find('.save-button').bind('click', function() {
 	var handlerUrl = runtime.handlerUrl(element, 'studio_submit');
+
 	var form_data = {
 	    likert: $(element).find('input[name=likert]').val(),
 	    likert0: $(element).find('input[name=likert0]').val(),
@@ -11,6 +12,10 @@ function FeedbackBlock(runtime, element, data) {
 	    likert4: $(element).find('input[name=likert4]').val(),
 	    freeform: $(element).find('input[name=freeform]').val(),
 	    placeholder: $(element).find('input[name=placeholder]').val(),
+		display_name: $(element).find('input[name=display_name]').val(),
+		voting_message: $(element).find('input[name=voting_message]').val(),
+		feedback_message: $(element).find('input[name=feedback_message]').val(),
+		show_aggregate_to_students: $(element).find('select[name=show_aggregate_to_students]').val() === 'True',
 	    icon_set: $(element).find('select[name=icon_set]').val()
 	};
 	runtime.notify('save', {state: 'start'});

--- a/feedback/templates/html/studio_view.html
+++ b/feedback/templates/html/studio_view.html
@@ -3,88 +3,114 @@
 <div class="wrapper-comp-settings is-active editor-with-buttons" id="settings-tab">
   <ul class="list-input settings-list">
     <li class="field comp-setting-entry is-set">{% trans "This XBlock allows you to collect student feedback on pieces of the course. This may be helpful either for course improvement, or to give students a chance to reflect on what they have done." %}</li>
-  
+
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label class="label setting-label" aria-describedby="ff_p_div">{% trans "Freeform prompt" %}
-          <input class="input setting-input" name="freeform" id="freeform" value="{{freeform}}" type="text" />
-        </label>
+        <label class="label setting-label" for="display_name">{% trans "Display name" %}</label>
+        <input class="input setting-input" name="display_name" id="display_name" value="{{display_name}}" type="text" />
       </div>
-      <span class="tip setting-help" id="ff_p_div">{% trans "Example: Please provide us feedback on this section." %}</span>
+      <span class="tip setting-help"> {% trans "The name of the component." %} </span>
     </li>
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label aria-describedby="placeholder_span" class="label setting-label">{% trans "Freeform placeholder" %}
-          <input class="input setting-input" name="placeholder" id="placeholder" value="{{placeholder}}" type="text" />
-        </label>
+        <label class="label setting-label" for="voting_message">{% trans "Voting message" %}</label>
+        <input class="input setting-input" name="voting_message" id="voting_message" value="{{voting_message}}" type="text" />
+      </div>
+      <span class="tip setting-help"> {% trans "The message to show after user vote." %} </span>
+    </li>
+
+    <li class="field comp-setting-entry is-set">
+      <div class="wrapper-comp-setting">
+        <label class="label setting-label" for="feedback_message">{% trans "Feedback message" %}</label>
+        <input class="input setting-input" name="feedback_message" id="feedback_message" value="{{feedback_message}}" type="text" />
+      </div>
+      <span class="tip setting-help"> {% trans "The message to show after user feedback." %} </span>
+    </li>
+
+    <li class="field comp-setting-entry is-set">
+      <div class="wrapper-comp-setting">
+        <label class="label setting-label" for="show_aggregate_to_students">{% trans "Show aggregate report to students" %}</label>
+        <select name="show_aggregate_to_students" value="{{show_aggregate_to_students}}">
+          <option value="False">{% trans "False" %}</option>
+          <option value="True">{% trans "True" %}</option>
+        </select>
+      </div>
+      <span class="tip setting-help"> {% trans "Wheter to show the aggregate report to students." %} </span>
+    </li>
+
+    <li class="field comp-setting-entry is-set">
+      <div class="wrapper-comp-setting">
+        <label class="label setting-label" aria-describedby="ff_p_div">{% trans "Freeform prompt" %}</label>
+        <input class="input setting-input" name="freeform" id="freeform" value="{{freeform}}" type="text" />
+      </div>
+      <span class="tip setting-help" id="ff_p_div">{% trans "Example: Please provide us feedback on this section."%}</span>
+    </li>
+
+    <li class="field comp-setting-entry is-set">
+      <div class="wrapper-comp-setting">
+        <label aria-describedby="placeholder_span" class="label setting-label">{% trans "Freeform placeholder"%}</label>
+        <input class="input setting-input" name="placeholder" id="placeholder" value="{{placeholder}}" type="text" />
       </div>
       <span id="placeholder_span" class="tip setting-help">{% trans "This is shown as grayed out text before the student has answered." %}</span>
     </li>
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label aria-describedby="icon_set_option" class="label setting-label">{% trans "Likert icon set" %}
-	<select name="icon_set">
-	  <option value="face">{% trans "Faces (happy to sad)" %}</option>
-	  <option value="midface">{% trans "Faces (sad to happy to sad)" %}</option>
-	  <option value="num">{% trans "Numeric" %}</option>
-	</select>
-	</label>
+        <label aria-describedby="icon_set_option" class="label setting-label">{% trans "Likert icon set" %}</label>
+        <select name="icon_set">
+          <option value="face">{% trans "Faces (happy to sad)" %}</option>
+          <option value="midface">{% trans "Faces (sad to happy to sad)" %}</option>
+          <option value="num">{% trans "Numeric" %}</option>
+        </select>
       </div>
-      <span id="icon_set_option" class="tip setting-help">{% trans "We can either show happy/sad faces, or numbers 1-5." %}</span>
+      <span id="icon_set_option" class="tip setting-help">{% trans "We can either show happy/sad faces, or numbers 1-5."%}</span>
     </li>
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label aria-describedby="lik_example" class="label setting-label">{% trans "Likert prompt" %}
-          <input class="input setting-input" name="likert" id="likert" value="{{likert}}" type="text" />
-        </label>
+        <label aria-describedby="lik_example" class="label setting-label">{% trans "Likert prompt" %}</label>
+        <input class="input setting-input" name="likert" id="likert" value="{{likert}}" type="text" />
       </div>
       <span id="lik_example" class="tip setting-help">{% trans "Example: Please rate your overall experience with this section." %}</span>
     </li>
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label aria-describedby="lik_excel" class="label setting-label">{% trans "Likert option 1" %}
-          <input class="input setting-input" name="likert0" id="likert0" value="{{likert0}}" type="text" />
-        </label>
+        <label aria-describedby="lik_excel" class="label setting-label">{% trans "Likert option 1" %}</label>
+        <input class="input setting-input" name="likert0" id="likert0" value="{{likert0}}" type="text" />
       </div>
       <span id="lik_excel" class="tip setting-help">{% trans "Example: Excellent!" %}</span>
     </li>
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label aria-describedby="lik_good" class="label setting-label">{% trans "Likert option 2" %}
-          <input class="input setting-input" name="likert1" id="likert1" value="{{likert1}}" type="text" />
-        </label>
+        <label aria-describedby="lik_good" class="label setting-label">{% trans "Likert option 2" %}</label>
+        <input class="input setting-input" name="likert1" id="likert1" value="{{likert1}}" type="text" />
       </div>
       <span id="lik_good" class="tip setting-help">{% trans "Example: Good" %}</span>
     </li>
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label aria-describedby="lik_ave" class="label setting-label">{% trans "Likert option 3" %}
-          <input class="input setting-input" name="likert2" id="likert2" value="{{likert2}}" type="text" />
-        </label>
+        <label aria-describedby="lik_ave" class="label setting-label">{% trans "Likert option 3" %}</label>
+        <input class="input setting-input" name="likert2" id="likert2" value="{{likert2}}" type="text" />
       </div>
       <span id="lik_ave" class="tip setting-help">{% trans "Example: Average" %}</span>
     </li>
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label aria-describedby="lik_fair" class="label setting-label">{% trans "Likert option 4" %}
-          <input class="input setting-input" name="likert3" id="likert3" value="{{likert3}}" type="text" />
-        </label>
+        <label aria-describedby="lik_fair" class="label setting-label">{% trans "Likert option 4" %}</label>
+        <input class="input setting-input" name="likert3" id="likert3" value="{{likert3}}" type="text" />
       </div>
       <span id="lik_fair" class="tip setting-help">{% trans "Example: Fair" %}</span>
     </li>
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label aria-describedby="lik_poor" class="label setting-label">{% trans "Likert option 5" %}
-          <input class="input setting-input" name="likert4" id="likert4" value="{{likert4}}" type="text" />
-        </label>
+        <label aria-describedby="lik_poor" class="label setting-label">{% trans "Likert option 5" %}</label>
+        <input class="input setting-input" name="likert4" id="likert4" value="{{likert4}}" type="text" />
       </div>
       <span id="lik_poor" class="tip setting-help">{% trans "Example: Poor" %}</span>
     </li>

--- a/feedback/templates/html/studio_view.html
+++ b/feedback/templates/html/studio_view.html
@@ -6,26 +6,26 @@
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label class="label setting-label" for="display_name">{% trans "Display name" %}</label>
+        <label class="label setting-label" for="display_name" aria-describedby="display_name_help">{% trans "Display name" %}</label>
         <input class="input setting-input" name="display_name" id="display_name" value="{{display_name}}" type="text" />
       </div>
-      <span class="tip setting-help"> {% trans "The name of the component." %} </span>
+      <span class="tip setting-help" id="display_name_help"> {% trans "The name of the component." %} </span>
     </li>
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label class="label setting-label" for="voting_message">{% trans "Voting message" %}</label>
+        <label class="label setting-label" for="voting_message" aria-describedby="voting_message_help">{% trans "Voting message" %}</label>
         <input class="input setting-input" name="voting_message" id="voting_message" value="{{voting_message}}" type="text" />
       </div>
-      <span class="tip setting-help"> {% trans "The message to show after user vote." %} </span>
+      <span class="tip setting-help" id="voting_message_help"> {% trans "The message to show after user vote." %} </span>
     </li>
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label class="label setting-label" for="feedback_message">{% trans "Feedback message" %}</label>
+        <label class="label setting-label" for="feedback_message" aria-describedby="feedback_message_help">{% trans "Feedback message" %}</label>
         <input class="input setting-input" name="feedback_message" id="feedback_message" value="{{feedback_message}}" type="text" />
       </div>
-      <span class="tip setting-help"> {% trans "The message to show after user feedback." %} </span>
+      <span class="tip setting-help" id="feedback_message_help"> {% trans "The message to show after user feedback." %} </span>
     </li>
 
     <li class="field comp-setting-entry is-set">
@@ -41,7 +41,7 @@
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label class="label setting-label" aria-describedby="ff_p_div">{% trans "Freeform prompt" %}</label>
+        <label class="label setting-label" for="freeform" aria-describedby="ff_p_div">{% trans "Freeform prompt" %}</label>
         <input class="input setting-input" name="freeform" id="freeform" value="{{freeform}}" type="text" />
       </div>
       <span class="tip setting-help" id="ff_p_div">{% trans "Example: Please provide us feedback on this section."%}</span>
@@ -49,7 +49,7 @@
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label aria-describedby="placeholder_span" class="label setting-label">{% trans "Freeform placeholder"%}</label>
+        <label class="label setting-label" for="placeholder" aria-describedby="placeholder_span">{% trans "Freeform placeholder"%}</label>
         <input class="input setting-input" name="placeholder" id="placeholder" value="{{placeholder}}" type="text" />
       </div>
       <span id="placeholder_span" class="tip setting-help">{% trans "This is shown as grayed out text before the student has answered." %}</span>
@@ -57,8 +57,8 @@
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label aria-describedby="icon_set_option" class="label setting-label">{% trans "Likert icon set" %}</label>
-        <select name="icon_set">
+        <label class="label setting-label" for="icon_set" aria-describedby="icon_set_option">{% trans "Likert icon set" %}</label>
+        <select name="icon_set" id="icon_set">
           <option value="face">{% trans "Faces (happy to sad)" %}</option>
           <option value="midface">{% trans "Faces (sad to happy to sad)" %}</option>
           <option value="num">{% trans "Numeric" %}</option>
@@ -69,7 +69,7 @@
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label aria-describedby="lik_example" class="label setting-label">{% trans "Likert prompt" %}</label>
+        <label class="label setting-label" for="likert" aria-describedby="lik_example">{% trans "Likert prompt" %}</label>
         <input class="input setting-input" name="likert" id="likert" value="{{likert}}" type="text" />
       </div>
       <span id="lik_example" class="tip setting-help">{% trans "Example: Please rate your overall experience with this section." %}</span>
@@ -77,7 +77,7 @@
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label aria-describedby="lik_excel" class="label setting-label">{% trans "Likert option 1" %}</label>
+        <label class="label setting-label" for="likert0" aria-describedby="lik_excel">{% trans "Likert option 1" %}</label>
         <input class="input setting-input" name="likert0" id="likert0" value="{{likert0}}" type="text" />
       </div>
       <span id="lik_excel" class="tip setting-help">{% trans "Example: Excellent!" %}</span>
@@ -85,7 +85,7 @@
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label aria-describedby="lik_good" class="label setting-label">{% trans "Likert option 2" %}</label>
+        <label class="label setting-label" for="likert1" aria-describedby="lik_good">{% trans "Likert option 2" %}</label>
         <input class="input setting-input" name="likert1" id="likert1" value="{{likert1}}" type="text" />
       </div>
       <span id="lik_good" class="tip setting-help">{% trans "Example: Good" %}</span>
@@ -93,7 +93,7 @@
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label aria-describedby="lik_ave" class="label setting-label">{% trans "Likert option 3" %}</label>
+        <label class="label setting-label" for="likert2" aria-describedby="lik_ave">{% trans "Likert option 3" %}</label>
         <input class="input setting-input" name="likert2" id="likert2" value="{{likert2}}" type="text" />
       </div>
       <span id="lik_ave" class="tip setting-help">{% trans "Example: Average" %}</span>
@@ -101,7 +101,7 @@
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label aria-describedby="lik_fair" class="label setting-label">{% trans "Likert option 4" %}</label>
+        <label class="label setting-label" for="likert3" aria-describedby="lik_fair">{% trans "Likert option 4" %}</label>
         <input class="input setting-input" name="likert3" id="likert3" value="{{likert3}}" type="text" />
       </div>
       <span id="lik_fair" class="tip setting-help">{% trans "Example: Fair" %}</span>
@@ -109,7 +109,7 @@
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label aria-describedby="lik_poor" class="label setting-label">{% trans "Likert option 5" %}</label>
+        <label class="label setting-label" for="likert4" aria-describedby="lik_poor">{% trans "Likert option 5" %}</label>
         <input class="input setting-input" name="likert4" id="likert4" value="{{likert4}}" type="text" />
       </div>
       <span id="lik_poor" class="tip setting-help">{% trans "Example: Poor" %}</span>

--- a/feedbacktests/test_feedback_unit.py
+++ b/feedbacktests/test_feedback_unit.py
@@ -20,7 +20,8 @@ def test_studio_view(feedback_xblock):
 def test_studio_submit(feedback_xblock):
     """ Test the FeedbackXBlock's save action """
     request_body = b"""{
-        "display_name": "foo"
+        "display_name": "foo",
+        "voting_message": "bar"
     }"""
     request = Mock(method='POST', body=request_body)
     response = feedback_xblock.studio_submit(request)

--- a/feedbacktests/test_feedback_unit.py
+++ b/feedbacktests/test_feedback_unit.py
@@ -21,10 +21,17 @@ def test_studio_submit(feedback_xblock):
     """ Test the FeedbackXBlock's save action """
     request_body = b"""{
         "display_name": "foo",
-        "voting_message": "bar"
+        "voting_message": "bar",
+        "feedback_message": "baz",
+        "show_aggregate_to_students": true
     }"""
     request = Mock(method='POST', body=request_body)
     response = feedback_xblock.studio_submit(request)
+
+    assert feedback_xblock.display_name == 'foo'
+    assert feedback_xblock.voting_message == 'bar'
+    assert feedback_xblock.feedback_message == 'baz'
+    assert feedback_xblock.show_aggregate_to_students is True
     assert response.status_code == 200 and {'result': 'success'} == response.json, response.json
 
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def package_data(pkg, roots):
 
 setup(
     name='feedback-xblock',
-    version='1.2.0',
+    version='1.3.0',
     description='XBlock for providing feedback on course content',
     long_description=README,
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
## Description

This PR:

* Improves the studio view of the FeedbackXBlock by adjusting the display of fields.
* Adds the following settings:
  - **Display name**: The display name shown to students.
  - **Voting message text**: The message to show after voting.
  - **Feedback message text**: The message to show after providing feedback.
  - **Show aggregate report to students**: Wheter to show aggregate report to students.

### Before

![image](https://github.com/openedx/FeedbackXBlock/assets/33465240/9f2bd68e-e3ea-44eb-85b4-f53eb47041fe)


### After

![image](https://github.com/openedx/FeedbackXBlock/assets/33465240/48e5ccac-b272-4766-8cc8-6b1130d0871d)
![image](https://github.com/openedx/FeedbackXBlock/assets/33465240/4893c3bc-e1c0-46b5-a943-fc641c8d963d)
![image](https://github.com/openedx/FeedbackXBlock/assets/33465240/43a544eb-b540-42a1-b3dd-d352d19e5cb2)
![image](https://github.com/openedx/FeedbackXBlock/assets/33465240/99c20208-40b3-4be7-a4a5-a5fd0b3a57ec)