### PR TITLE
fix!: drop support of python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python-version: ['3.8', '3.11', '3.12']
-        toxenv: [py38-django42, quality]
+        python-version: ['3.11', '3.12']
+        toxenv: [django42, quality]
 
     steps:
     - uses: actions/checkout@v3
@@ -36,7 +36,7 @@ jobs:
       run: tox
 
     - name: Run Coverage
-      if: matrix.python-version == '3.8' && matrix.toxenv=='py38-django42'
+      if: matrix.python-version == '3.11' && matrix.toxenv=='py311-django42'
       uses: codecov/codecov-action@v4
       with:
         flags: unittests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,4 +8,5 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-backports.zoneinfo;python_version<"3.9"
+# Common constraints for edx repos
+-c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def package_data(pkg, roots):
 
 setup(
     name='feedback-xblock',
-    version='1.6.0',
+    version='2.0.0',
     description='XBlock for providing feedback on course content',
     long_description=README,
     long_description_content_type='text/x-rst',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,311,312}-django{42}, quality
+envlist = py{311,312}-django{42}, quality
 
 [testenv]
 allowlist_externals =


### PR DESCRIPTION
drop support of python 3.8

For reviewer: Another [PR](https://github.com/openedx/XBlock/pull/716) of dropping py 3.8