### PR TITLE
fix: fixed the lms link imports to avoid a runtime error

### DIFF
--- a/feedback/extensions/filters.py
+++ b/feedback/extensions/filters.py
@@ -9,7 +9,7 @@ from openedx_filters import PipelineStep
 from web_fragments.fragment import Fragment
 
 try:
-    from cms.djangoapps.contentstore.utils import get_lms_link_for_item
+    from feedback.utils import get_lms_link_for_item
     from lms.djangoapps.courseware.block_render import (get_block_by_usage_id,
                                                         load_single_xblock)
     from openedx.core.djangoapps.enrollments.data import get_user_enrollments

--- a/feedback/settings/test.py
+++ b/feedback/settings/test.py
@@ -22,3 +22,5 @@ FEATURES = {
 }
 
 SECRET_KEY = 'fake-key'
+
+LMS_ROOT_URL = "https://example.com"

--- a/feedback/utils.py
+++ b/feedback/utils.py
@@ -18,7 +18,9 @@ def get_lms_link_for_item(location, preview=False):
     assert isinstance(location, UsageKey)
 
     try:
-        from openedx.core.djangoapps.site_configuration.models import SiteConfiguration # pylint: disable=import-outside-toplevel
+        # pylint: disable=import-outside-toplevel
+        from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
+
     except ImportError:
         return None  # or raise a clearer error, or fallback
 

--- a/feedback/utils.py
+++ b/feedback/utils.py
@@ -1,6 +1,39 @@
 """Utilities for feedback app"""
 
+# feedbackblock/feedback/utils.py
+from urllib.parse import urlencode, urlparse, urlunparse
+from opaque_keys.edx.keys import UsageKey
+from django.conf import settings
+from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 
 def _(text):
     """Dummy `gettext` replacement to make string extraction tools scrape strings marked for translation"""
     return text
+
+def get_lms_link_for_item(location, preview=False):
+    """
+    Returns an LMS link to the course with a jump_to to the provided location.
+    """
+    assert isinstance(location, UsageKey)
+
+    lms_base = SiteConfiguration.get_value_for_org(
+        location.org,
+        "LMS_ROOT_URL",
+        settings.LMS_ROOT_URL
+    )
+    query_string = ''
+
+    if lms_base is None:
+        return None
+
+    if preview:
+        query_string = urlencode({'preview': '1'})
+
+    url_parts = list(urlparse(lms_base))
+    url_parts[2] = '/courses/{course_key}/jump_to/{location}'.format(
+        course_key=str(location.course_key),
+        location=str(location),
+    )
+    url_parts[4] = query_string
+
+    return urlunparse(url_parts)

--- a/feedback/utils.py
+++ b/feedback/utils.py
@@ -18,7 +18,7 @@ def get_lms_link_for_item(location, preview=False):
     assert isinstance(location, UsageKey)
 
     try:
-        from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
+        from openedx.core.djangoapps.site_configuration.models import SiteConfiguration # pylint: disable=import-outside-toplevel
     except ImportError:
         return None  # or raise a clearer error, or fallback
 

--- a/feedback/utils.py
+++ b/feedback/utils.py
@@ -22,7 +22,7 @@ def get_lms_link_for_item(location, preview=False):
         from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 
     except ImportError:
-        return None  # or raise a clearer error, or fallback
+        return None
 
     lms_base = SiteConfiguration.get_value_for_org(
         location.org,

--- a/feedback/utils.py
+++ b/feedback/utils.py
@@ -6,9 +6,11 @@ from opaque_keys.edx.keys import UsageKey
 from django.conf import settings
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 
+
 def _(text):
     """Dummy `gettext` replacement to make string extraction tools scrape strings marked for translation"""
     return text
+
 
 def get_lms_link_for_item(location, preview=False):
     """

--- a/feedbacktests/test_utils.py
+++ b/feedbacktests/test_utils.py
@@ -1,6 +1,8 @@
 from feedback.utils import get_lms_link_for_item
 from opaque_keys.edx.keys import UsageKey
 from unittest.mock import Mock
+import sys
+import types
 
 
 def test_get_lms_link_default(monkeypatch):
@@ -9,19 +11,59 @@ def test_get_lms_link_default(monkeypatch):
     location.course_key = "course-v1:edX+DemoX+2024"
     location.__str__ = lambda self=location: "dummy"
 
-    class MockSettings:
-        LMS_ROOT_URL = "https://example.com"
-    monkeypatch.setattr("feedback.utils.settings", MockSettings)
+    class MockSiteConfiguration:
+        @staticmethod
+        def get_value_for_org(org, key, default):
+            return default  # simulate missing org-specific config
+
+    monkeypatch.setitem(
+        sys.modules,
+        "openedx.core.djangoapps.site_configuration.models",
+        types.SimpleNamespace(SiteConfiguration=MockSiteConfiguration)
+    )
+
+    result = get_lms_link_for_item(location)
+    assert result == "https://example.com/courses/course-v1:edX+DemoX+2024/jump_to/dummy"
+
+
+def test_get_lms_link_with_null_lms_base(monkeypatch):
+    location = Mock(spec=UsageKey)
+    location.org = "edX"
+    location.course_key = "dummy"
+    location.__str__ = lambda self=location: "dummy"
 
     class MockSiteConfiguration:
         @staticmethod
         def get_value_for_org(org, key, default):
-            return default  # simulate missing config
+            return None  # simulate LMS base not set
+
     monkeypatch.setitem(
-        __import__("sys").modules,
+        sys.modules,
         "openedx.core.djangoapps.site_configuration.models",
-        __import__("types").SimpleNamespace(
-            SiteConfiguration=MockSiteConfiguration))
+        types.SimpleNamespace(SiteConfiguration=MockSiteConfiguration)
+    )
 
     result = get_lms_link_for_item(location)
-    assert result == "https://example.com/courses/course-v1:edX+DemoX+2024/jump_to/dummy"
+    assert result is None
+
+
+def test_get_lms_link_with_preview(monkeypatch):
+    location = Mock(spec=UsageKey)
+    location.org = "edX"
+    location.course_key = "course-v1:edX+DemoX+2024"
+    location.__str__ = lambda self=location: "dummy"
+
+    class MockSiteConfiguration:
+        @staticmethod
+        def get_value_for_org(org, key, default):
+            return "https://fallback.com"
+
+    monkeypatch.setitem(
+        sys.modules,
+        "openedx.core.djangoapps.site_configuration.models",
+        types.SimpleNamespace(SiteConfiguration=MockSiteConfiguration)
+    )
+
+    result = get_lms_link_for_item(location, preview=True)
+    assert result == "https://fallback.com/courses/course-v1:edX+DemoX+2024/jump_to/dummy?preview=1"
+

--- a/feedbacktests/test_utils.py
+++ b/feedbacktests/test_utils.py
@@ -1,0 +1,27 @@
+from feedback.utils import get_lms_link_for_item
+from opaque_keys.edx.keys import UsageKey
+from unittest.mock import Mock
+
+
+def test_get_lms_link_default(monkeypatch):
+    location = Mock(spec=UsageKey)
+    location.org = "edX"
+    location.course_key = "course-v1:edX+DemoX+2024"
+    location.__str__ = lambda self=location: "dummy"
+
+    class MockSettings:
+        LMS_ROOT_URL = "https://example.com"
+    monkeypatch.setattr("feedback.utils.settings", MockSettings)
+
+    class MockSiteConfiguration:
+        @staticmethod
+        def get_value_for_org(org, key, default):
+            return default  # simulate missing config
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "openedx.core.djangoapps.site_configuration.models",
+        __import__("types").SimpleNamespace(
+            SiteConfiguration=MockSiteConfiguration))
+
+    result = get_lms_link_for_item(location)
+    assert result == "https://example.com/courses/course-v1:edX+DemoX+2024/jump_to/dummy"


### PR DESCRIPTION
### Description

This PR resolves a critical issue where the LMS crashes when the Feedback XBlock is loaded. The problem stems from the XBlock importing a utility function from the openedx.core.djangoapps.content.search.models module, which is only available in the CMS (Studio) context. More information here: https://github.com/openedx/FeedbackXBlock/issues/164

Because the content.search app is not installed or initialized in the LMS, attempting to import from it causes runtime errors, resulting in LMS failures when rendering or initializing the XBlock.

### Solution

To fix this, the offending import has been fully removed, and the required functionality has been re-implemented locally within the utils.py file of the Feedback XBlock. This decouples the XBlock from platform-specific CMS-only dependencies, ensuring it works in both LMS and Studio environments.

This solution avoids runtime exceptions and ensures the XBlock operates independently of internal platform modules not shared across services.

🔍 Why this matters

    Prevents LMS from crashing due to unavailable CMS-only Django apps.

    Makes the Feedback XBlock more robust, self-contained, and platform-agnostic.

    Enables safe use of the XBlock across different Open edX deployments and service boundaries.

### How to test

1. Install the xblock using this branch
2. Install the component in studio adding "feedback" to the advanced settings in studio
3. Go to your course as an admin and go to the Instructor tab
4. You should see no errors and the xblock rendering correctly
![image](https://github.com/user-attachments/assets/c0de71ba-f5f6-4627-b569-322fbbe0e31f)

